### PR TITLE
Split man page options list into sections

### DIFF
--- a/cowsay.1
+++ b/cowsay.1
@@ -2,12 +2,12 @@
 .\"     Title: cowsay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 05/28/2020
+.\"      Date: 07/18/2022
 .\"    Manual: Cowsay Manual
 .\"    Source: Cowsay 3.8.0-SNAPSHOT
 .\"  Language: English
 .\"
-.TH "COWSAY" "1" "05/28/2020" "Cowsay 3\&.8\&.0\-SNAPSHOT" "Cowsay Manual"
+.TH "COWSAY" "1" "07/18/2022" "Cowsay 3\&.8\&.0\-SNAPSHOT" "Cowsay Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -46,6 +46,7 @@ If the program is invoked as \fBcowthink\fR then the cow will think its message 
 .SH "OPTIONS"
 .sp
 There are several provided modes which change the appearance of the cow depending on its particular emotional/physical state\&.
+.SS "Cow modification"
 .PP
 \fB\-b\fR
 .RS 4
@@ -106,6 +107,7 @@ and
 \fB\-T\fR
 will be lost if one of the provided modes is used\&.
 .RE
+.SS "Cow selection"
 .PP
 \fB\-f\fR
 .RS 4
@@ -130,6 +132,7 @@ Chooses a random cow from the cows on the
 Enables true\-color (24\-bit) cows\&. Currently only has an effect when used in conjunction with
 \fB\-r\fR\&.
 .RE
+.SS "Non\-cow operations"
 .PP
 \fB\-l\fR
 .RS 4

--- a/cowsay.1.adoc
+++ b/cowsay.1.adoc
@@ -38,6 +38,8 @@ OPTIONS
 -------
 There are several provided modes which change the appearance of the cow depending on its particular emotional/physical state.
 
+Cow modification
+~~~~~~~~~~~~~~~~
 *-b*::
     Invokes Borg mode.
 
@@ -65,6 +67,8 @@ There are several provided modes which change the appearance of the cow dependin
 *-e*::
     Selects the appearance of the cow's eyes, in which case the first two characters of the argument string 'eye_string' will be used.  The default eyes are *oo*.  The tongue is similarly configurable through *-T* and 'tongue_string'; it must be two characters and does not appear by default.  However, it does appear in the 'dead' and 'stoned' modes.  Any configuration done by *-e* and *-T* will be lost if one of the provided modes is used.
 
+Cow selection
+~~~~~~~~~~~~~
 *-f*::
     Specifies a particular cow picture file ('cowfile') to use.  If the cowfile spec resolves to an existing file, then it will be interpreted as a path to the cowfile.  Otherwise, cowsay will search the COWPATH for a cowfile with that name. Additional cowpath entries may be specified in the *COWPATH* environment variable. To list all cowfiles on the current *COWPATH*, invoke *cowsay* with the *-l* switch.
 
@@ -74,6 +78,8 @@ There are several provided modes which change the appearance of the cow dependin
 *-C*::
     Enables true-color (24-bit) cows. Currently only has an effect when used in conjunction with *-r*.
 
+Non-cow operations
+~~~~~~~~~~~~~~~~~~
 *-l*::
     Lists the defined cows on the current *COWPATH*. Displays it in a human-readable pretty-printed format when displaying to a terminal device. When sent to a non-terminal device, outputs the list in a parsing-friendly format with one cow name per line and no headers or blank lines.
 

--- a/cowthink.1
+++ b/cowthink.1
@@ -1,1 +1,1 @@
-.so cowsay.1
+.so man1/cowsay.1


### PR DESCRIPTION
The OPTIONS list in the man page is very long. Separating it
into subsections helps read the long list.

The fact that the options have already been ordered in a way
which already groups them into those sections indicates that
these sections make sense.

I have no idea why the cowthink.1 file changes on `make man`,
but I accept that `make man` knows what it is doing.