### PR TITLE
Revert cowthink.1 to point to cowsay.1 in the same dir

### DIFF
--- a/cowthink.1
+++ b/cowthink.1
@@ -1,1 +1,3 @@
-.so man1/cowsay.1
+.\" Keep this pointing to cowsay.1, not man1/cowsay.1 to keep
+.\" "man ./cowthink.1" working inside a cowsay source tree.
+.so cowsay.1


### PR DESCRIPTION
For a source tree from git or tarball, if the `cowthink.1` file in the source tree is `.so cowsay.1`, running `man ./cowthink.1` will open the `cowsay.1` file from the source tree, which is OK.

HOWEVER, if the `cowthink.1` file in the source tree is `.so man1/cowsay.1`, running `man ./cowthink.1` will either show the **wrong** man page from `/usr/share/man/man1/cowsay.1` (or elsewhere in MANPATH, I presume), or if no `cowsay.1` file is found in MANPATH, will show an **empty** page.

That is clearly wrong, so reverting to the old `cowthink.1` file which points `man` to the `cowsay.1` file in the same directory is clearly better.

This is a new PR as I cannot reopen the PR https://github.com/cowsay-org/cowsay/pull/24 in which I introduced the problem this PR fixes.