### PR TITLE
Get Makefile to conform to GNU Makefile conventions, and be better

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,3 +10,6 @@ Or:
 
   make install prefix=/path/to/my/prefix
 
+Or:
+
+  make install DESTDIR=/path/to/buildroot

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,43 @@ datadir = ${datarootdir}
 docdir = ${datarootdir}/doc/${PACKAGE_TARNAME}
 sysconfdir = ${prefix}/etc
 mandir=${datarootdir}/man
+
+pkgdatadir = ${datadir}/${PACKAGE_TARNAME}
+cowsdir = ${pkgdatadir}/cows
+sitecowsdir = ${pkgdatadir}/site-cows
+
+pkgsysconfdir = ${sysconfdir}/${PACKAGE_TARNAME}
+cowpathdir = ${pkgsysconfdir}/cowpath.d
+
 srcdir = .
 
 SHELL = /bin/sh
-INSTALL = install
+
+# Make standard tools overridable, e.g. for testing with busybox
+ASCIIDOCTOR = asciidoctor
+AWK = awk
+CUT = cut
+GREP = grep
+EGREP = $(GREP) -E
+INSTALL = install -c
 INSTALL_PROGRAM = $(INSTALL)
 INSTALL_DATA = ${INSTALL} -m 644
+INSTALL_DIR = $(INSTALL) -d
 LN = ln
+LN_S = $(LN) -s
+PRINTF = printf
+SORT = sort
+WC = wc
+
+# If you implement support for *.pm cows, add share/cows/*.pm here.
+#
+# Note that this is a list of shell globs to be evaluated by the
+# shell, not a list of files to be evaluated by make.
+COW_FILES = share/cows/*.cow
+
+.PHONY: all
+all:
+	@echo "Nothing to do - 'make all' is a no-op."
 
 .PHONY: clean man install uninstall
 
@@ -25,32 +55,66 @@ clean:
 
 # The 'man' target creates cowsay.1, cowthink.1, and other man pages.
 #
-# The 'man' target is intended for use at authoring time, not build time, so it is not
-# part of the normal build sequence, and its outputs are checked in to the source tree.
-# This is partially to simplify the build process, and partially to preserve the internal
-# "update" timestamp inside the man pages. We do this at authoring/build time instead of
-# install time to avoid introducing a dependency on Asciidoctor for users.
+# The 'man' target is intended for use at authoring time, not at build
+# time, so it is not part of the normal build sequence, and its
+# outputs are checked into the source repo.
+#
+# This is partially to simplify the build process, and partially to
+# preserve the internal "update" timestamp inside the man pages. We
+# also do this at authoring time instead of install time to avoid
+# introducing a dependency on Asciidoctor for users.
 
 man: cowsay.1
 
 cowsay.1: cowsay.1.adoc
-	asciidoctor -b manpage cowsay.1.adoc
+	$(ASCIIDOCTOR) -b manpage cowsay.1.adoc
 
-# This dependency specification is woefully incomplete, and assumes you'll just do a fresh
-# install each time. This is probably fine.
-install: cowsay cowsay.1 cowthink.1
-	$(INSTALL) -d $(DESTDIR)$(prefix)
-	$(INSTALL) -d $(DESTDIR)$(bindir)
+install:
+	$(INSTALL_DIR) $(DESTDIR)$(cowpathdir)
+	$(INSTALL_DIR) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) cowsay $(DESTDIR)$(bindir)/cowsay
-	$(LN) -s cowsay $(DESTDIR)$(bindir)/cowthink
-	$(INSTALL) -d $(DESTDIR)$(mandir)/man1
-	$(INSTALL_DATA) cowsay.1 $(DESTDIR)$(mandir)/man1
-	$(INSTALL_DATA) cowthink.1 $(DESTDIR)$(mandir)/man1
-	$(INSTALL) -d $(DESTDIR)$(datadir)/cowsay
-	cp -R share/cows $(DESTDIR)$(datadir)/cowsay
-	$(INSTALL) -d $(DESTDIR)$(datadir)/cowsay/site-cows
+	rm -f $(DESTDIR)$(bindir)/cowthink
+	$(LN_S) cowsay $(DESTDIR)$(bindir)/cowthink
+	$(INSTALL_DIR) $(DESTDIR)$(mandir)/man1
+	$(INSTALL_DATA) cowsay.1 $(DESTDIR)$(mandir)/man1/cowsay.1
+	rm -f $(DESTDIR)$(mandir)/man1/cowthink.1
+	$(LN_S) cowsay.1 $(DESTDIR)$(mandir)/man1/cowthink.1
+	$(INSTALL_DIR) $(DESTDIR)$(cowsdir)
+	$(INSTALL_DATA) $(COW_FILES) $(DESTDIR)$(cowsdir)
+	$(INSTALL_DIR) $(DESTDIR)$(sitecowsdir)
 
 uninstall:
-	rm -f $(DESTDIR)$(bindir)/cowsay $(DESTDIR)$(bindir)/cowthink
-	rm -f $(DESTDIR)$(mandir)/man1/cowsay.1 $(DESTDIR)$(mandir)/man1/cowthink.1
-	rm -rf $(DESTDIR)$(datadir)/cowsay
+	@set -e; \
+	for f in \
+	  $(DESTDIR)$(bindir)/cowsay \
+	  $(DESTDIR)$(bindir)/cowthink \
+	  $(DESTDIR)$(mandir)/man1/cowsay.1 \
+	  $(DESTDIR)$(mandir)/man1/cowthink.1 \
+        ; do \
+	  if test -f "$$f" || test -L "$$f"; then \
+	    echo "rm -f $$f"; \
+	    rm -f "$$f"; \
+	  fi; \
+	done
+	@set -e; \
+	for cow in $(COW_FILES); do \
+	  dcow="$(DESTDIR)$(cowsdir)/$$(basename "$$cow")"; \
+	  if test -f "$$dcow"; then \
+	    echo "rm -f $$dcow"; \
+	    rm -f "$$dcow"; \
+	  fi; \
+	done
+	@set -e; \
+	for dir in $(cowsdir) $(sitecowsdir) $(pkgdatadir) $(cowpathdir) $(pkgsysconfdir); do \
+	  $(PRINTF) "%s\n" "$$dir"; \
+	done \
+	| $(AWK) '{ print length, $$0 }' | $(SORT) -n -r | $(CUT) -d" " -f2- \
+	| while read dir; do \
+	  if test "x$$($(PRINTF) "%s" "$$dir" | $(EGREP) '/.*/$(PACKAGE_TARNAME)(/|$$)' | $(WC) -c)" != x0; then \
+	    dd="$(DESTDIR)$${dir}"; \
+	    if test -d "$$dd"; then \
+	      echo "rmdir $$dd"; \
+	      rmdir "$$dd" ||:; \
+	    fi; \
+	  fi; \
+	done


### PR DESCRIPTION
This fixes bugs like trying removing the wrong directory, introduces some make variables to help with DRY, stops installing cow files cowsay cannot handle and possibly non-cow files, allows installation preserving file timestamps on install, replaces the installed cowthink.1 with a symlink, etc.

This also allows packagers to preserve file timestamps at "make install" time by setting `INSTALL_DATA="install -p -m 0644"` and `INSTALL_PROGRAM="install -p"` or maybe just `INSTALL="install -p"`, and it also stops installing files using cp which respects umask.

Overall, this would make it possible for e.g. the Fedora cowsay package to drop the custum install code.