### PR TITLE
Fix uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ install: cowsay.1
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/cowsay $(DESTDIR)$(bindir)/cowthink
 	rm -f $(DESTDIR)$(mandir)/man1/cowsay.1 $(DESTDIR)$(mandir)/man1/cowthink.1
-	rm -rf $(DESTDIR)$(datadir)/cows
+	rm -rf $(DESTDIR)$(datadir)/cowsay


### PR DESCRIPTION
Continuing the work in the commit 306d8e7ed0b14288fc8ec459cf7edc05c1533d9b, where cows and site-cows were moved to $(datadir)/share/cowsay