### PR TITLE
[doc] update license for alpaca.cow to standard Cowsay "GPLv1+ & Artistic 1.0"

### DIFF
--- a/copyright
+++ b/copyright
@@ -21,7 +21,7 @@ License: COWSAY
 
 Files: share/cowsay/alpaca.cow
 Copyright: 2022 Joel Maximilian Mai <joel@maispace.de>
-License: GPL-3.0-only
+License: COWSAY
 
 Files: share/cowsay/cows/bong.cow
 Copyright: 1999 Lars Smith <lars@csua.berkeley.edu>


### PR DESCRIPTION
This updates the `copyright` file to reflect @mai-space's application of expanded "GPLv1+ & Artistic 1.0" license grant to their `alpaca.cow` contribution, bringing its licensing in line with the original Cowsay licensing terms, per https://github.com/cowsay-org/cowsay/pull/33#issuecomment-2510206345.